### PR TITLE
Fix(user): Prevent data loss in user profile update

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -23,8 +23,22 @@ const UserController = {
         return res.status(400).json({ success: false, message: 'Validation failed', errors: errors.array() });
       }
 
-      const { first_name, last_name, phone } = req.body;
-      const result = await UserModel.updateProfile(req.user.id, { first_name, last_name, phone });
+      const updateData = {};
+      if (req.body.first_name !== undefined) {
+        updateData.first_name = req.body.first_name;
+      }
+      if (req.body.last_name !== undefined) {
+        updateData.last_name = req.body.last_name;
+      }
+      if (req.body.phone !== undefined) {
+        updateData.phone = req.body.phone;
+      }
+
+      if (Object.keys(updateData).length === 0) {
+        return res.status(400).json({ success: false, message: 'No fields to update' });
+      }
+
+      const result = await UserModel.updateProfile(req.user.id, updateData);
       if (result.affectedRows === 0) {
         return res.status(400).json({ success: false, message: 'No fields to update' });
       }


### PR DESCRIPTION
The `updateProfile` controller function was unconditionally passing all profile fields (`first_name`, `last_name`, `phone`) to the model for an update, even if they were not present in the request body. This resulted in `undefined` values being passed, which could lead to unintentional data loss by nullifying existing user data in the database.

This commit modifies the `updateProfile` function to dynamically build an `updateData` object containing only the fields explicitly provided in the request. This ensures that only the intended fields are updated, preserving the integrity of the user's profile data.

Additionally, the check for `affectedRows` is preserved to ensure that the update operation was successful and actually modified the database.